### PR TITLE
Smoothed recoil, added bullet emissions for weapon montages

### DIFF
--- a/Content/Weapons/BulletEmitter_AK.uasset
+++ b/Content/Weapons/BulletEmitter_AK.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e8c721fa78decf414ddf03d48b9a285a8f467911e879c299a843f9e83ab661c
+size 439955

--- a/Content/Weapons/BulletEmitter_Spas.uasset
+++ b/Content/Weapons/BulletEmitter_Spas.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82a0fbd843049dba21bb31b53a5adb67cc2a8f1af8d4bf1e88f37c2bc68e046a
+size 439938

--- a/Content/Weapons/WeaponComponents/HCO_DUP_AK47_COmponent.uasset
+++ b/Content/Weapons/WeaponComponents/HCO_DUP_AK47_COmponent.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1f34163074da4ebf088021f3a39a86cd6239c3f27a8c07bdc25e5d966a66b02
+size 333692

--- a/Content/Weapons/WeaponComponents/HCO_DUP_BP_Shotgun_Component1.uasset
+++ b/Content/Weapons/WeaponComponents/HCO_DUP_BP_Shotgun_Component1.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fbfea7aec2122c9d05845d0e04687893ca257b7d6f5ff0b0b18d34c29e8f676
+size 275838

--- a/Content/Weapons/WeaponModels/AK-47/HCO_AK47_FInal_Skeleton_Montage.uasset
+++ b/Content/Weapons/WeaponModels/AK-47/HCO_AK47_FInal_Skeleton_Montage.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a98847e8dc3f80fb831908d1eab516ee4ffb33d51751c13c4cf61dd49ce0da2d
+size 12938

--- a/Content/Weapons/WeaponModels/Shotgun/HCO_DUP_Shotgun_Skeleton_Montage.uasset
+++ b/Content/Weapons/WeaponModels/Shotgun/HCO_DUP_Shotgun_Skeleton_Montage.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2cbffe9f5a6953c08d62dcb548ca7e50a6da9b9f9a7379ac1e763aaeac00f6d7
+size 13252

--- a/Content/Weapons/WeaponModels/SpasShellMesh.uasset
+++ b/Content/Weapons/WeaponModels/SpasShellMesh.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad603a5e339befbc5860c492f5407a79e500ddaa139bede70dbe5e9d737c30f7
+size 25373


### PR DESCRIPTION
Changes in this PR:
Ak47 and Shotgun should have less intense recoil
Ak47 and Shotgun now emit bullet shells when fired, using new particle emitters
Added a shotgun shell asset to the game, created by canibilizing the shotgun model. 